### PR TITLE
Add validation for wavelet utilities

### DIFF
--- a/src/main/java/ai/prophetizo/wavelet/WaveletOperations.java
+++ b/src/main/java/ai/prophetizo/wavelet/WaveletOperations.java
@@ -140,7 +140,7 @@ public final class WaveletOperations {
          */
         public double estimateSpeedup(int signalLength) {
             if (signalLength < 0) {
-                throw new IllegalArgumentException("Signal length must be non-negative");
+                throw new IllegalArgumentException("Signal length cannot be negative");
             }
             if (!vectorizationEnabled || signalLength < 64) {
                 return 1.0;

--- a/src/main/java/ai/prophetizo/wavelet/WaveletOperations.java
+++ b/src/main/java/ai/prophetizo/wavelet/WaveletOperations.java
@@ -76,6 +76,9 @@ public final class WaveletOperations {
      * @throws IllegalArgumentException if threshold is negative
      */
     public static double[] softThreshold(double[] coefficients, double threshold) {
+        if (coefficients == null) {
+            throw new IllegalArgumentException("Coefficients array cannot be null");
+        }
         if (threshold < 0) {
             throw new IllegalArgumentException("Threshold must be non-negative");
         }
@@ -98,6 +101,9 @@ public final class WaveletOperations {
      * @throws IllegalArgumentException if threshold is negative
      */
     public static double[] hardThreshold(double[] coefficients, double threshold) {
+        if (coefficients == null) {
+            throw new IllegalArgumentException("Coefficients array cannot be null");
+        }
         if (threshold < 0) {
             throw new IllegalArgumentException("Threshold must be non-negative");
         }
@@ -133,6 +139,9 @@ public final class WaveletOperations {
          * @return estimated speedup factor
          */
         public double estimateSpeedup(int signalLength) {
+            if (signalLength < 0) {
+                throw new IllegalArgumentException("Signal length must be non-negative");
+            }
             if (!vectorizationEnabled || signalLength < 64) {
                 return 1.0;
             }

--- a/src/test/java/ai/prophetizo/wavelet/WaveletOperationsTest.java
+++ b/src/test/java/ai/prophetizo/wavelet/WaveletOperationsTest.java
@@ -1,0 +1,26 @@
+package ai.prophetizo.wavelet;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class WaveletOperationsTest {
+
+    @Test
+    void softThresholdNullCoefficientsThrows() {
+        assertThrows(IllegalArgumentException.class,
+                () -> WaveletOperations.softThreshold(null, 0.5));
+    }
+
+    @Test
+    void hardThresholdNullCoefficientsThrows() {
+        assertThrows(IllegalArgumentException.class,
+                () -> WaveletOperations.hardThreshold(null, 0.5));
+    }
+
+    @Test
+    void estimateSpeedupNegativeSignalLengthThrows() {
+        WaveletOperations.PerformanceInfo info =
+                new WaveletOperations.PerformanceInfo(false, "test", "N/A", "");
+        assertThrows(IllegalArgumentException.class, () -> info.estimateSpeedup(-1));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure null coefficient arrays are rejected in soft and hard threshold operations
- validate signal length in PerformanceInfo.estimateSpeedup
- add tests covering new validations

## Testing
- `mvn -q -Djacoco.skip=true test` *(fails: Could not resolve org.jacoco:jacoco-maven-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899b5de3f5c832cb34cd5036c96f108